### PR TITLE
Support SPD files with irregular surface_* tables

### DIFF
--- a/sn2md/importers/atelier.py
+++ b/sn2md/importers/atelier.py
@@ -75,11 +75,12 @@ def read_tiles_data(spd_file_path: str) -> list[dict]:
 
     tiles_data = []
     # Iterate over the layers from the top layer to the bottom layer
-    for i in range(len(layers), 0, -1):
-        if is_not_visible(layers[len(layers) - i]):
+    for layer in layers:
+        if is_not_visible(layer):
             continue
         # Fetch tiles, ordering them by tid.  Replace with the hardcoded `tids` list
-        cursor.execute(f"SELECT tid, tile FROM surface_{i} ORDER BY tid ASC;")
+        surface_idx = ord(layer[2])
+        cursor.execute(f"SELECT tid, tile FROM surface_{surface_idx} ORDER BY tid ASC;")
         tile_dict = {tid: tile_data for tid, tile_data in cursor.fetchall()}
         tiles_data.append(tile_dict)
 


### PR DESCRIPTION
The current code does not work with SPD files produced by my Manta for a couple of reasons:
- My SPDs have a Layer 0 corresponding to surface_0 - maybe this is an addition in a new version of Atelier. This throws off the indexing because the code looks for surface_1 and surface_2, but what I actually have are surface_0 and surface_1
- After deleting and re-creating layers, or changing the order of layers, the layer index doesnt match the suface table number

For example, in a SPD file I just created, I have:
 - layer "New" is surface_7
 - layer "Layer 5" is surface_6
 - layer "Layer 3" is surface_5
 - layer "Layer 4" is surface_4
 - layer "Layer 2" is surface_2
 - layer "Layer 0" is surface_0

Tables surface_1 and surface_3 no longer exist since I deleted those layers.

From my testing I'm pretty sure the 3rd byte of the ls entry corresponds to the number of the surface table of the layer.