### PR TITLE
Add versioned metadata handling

### DIFF
--- a/sn2md/importer.py
+++ b/sn2md/importer.py
@@ -217,7 +217,7 @@ def verify_metadata_file(config: Config, output: str, file_name: str) -> None:
     output_path = output_path_template.render(basic_context)
     output_path = os.path.join(output, output_path)
 
-    check_metadata_file(output_path)
+    check_metadata_file(output_path, file_name)
 
 
 def import_supernote_file_core(

--- a/sn2md/metadata.py
+++ b/sn2md/metadata.py
@@ -8,7 +8,64 @@ from .types import ConversionMetadata
 logger = logging.getLogger(__name__)
 
 
-def check_metadata_file(metadata_file: str) -> ConversionMetadata | None:
+def _load_metadata_unversioned(data) -> list[ConversionMetadata]:
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError("Invalid metadata format")
+
+    return [ConversionMetadata(**entry) for entry in data]
+
+
+def _load_metadata_v1(data) -> list[ConversionMetadata]:
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError("Invalid metadata format")
+
+    entries: list[ConversionMetadata] = []
+    for entry in data:
+        if entry.get("version") != 1:
+            raise ValueError("Unsupported metadata version")
+
+        entries.append(ConversionMetadata(**entry))
+
+    return entries
+
+
+def _load_metadata_entries(metadata_path: str) -> list[ConversionMetadata]:
+    with open(metadata_path, "r") as f:
+        data = yaml.safe_load(f) or []
+
+    if isinstance(data, list):
+        if not data:
+            return []
+
+        if all("version" not in entry for entry in data):
+            return _load_metadata_unversioned(data)
+
+        if all(entry.get("version") == 1 for entry in data):
+            return _load_metadata_v1(data)
+
+        if any("version" in entry for entry in data):
+            raise ValueError("Unsupported metadata version")
+
+    if isinstance(data, dict):
+        if "version" not in data:
+            return _load_metadata_unversioned(data)
+
+        if data.get("version") == 1:
+            return _load_metadata_v1(data)
+
+    if isinstance(data, dict) and "version" in data:
+        raise ValueError("Unsupported metadata version")
+
+    raise ValueError("Unsupported metadata format or version")
+
+
+def check_metadata_file(
+    metadata_file: str, input_file: str | None = None
+) -> ConversionMetadata | None:
     """Check the hashes of the source file against the metadata.
 
     Raises a ValueError if the source file hasn't been modified.
@@ -17,29 +74,41 @@ def check_metadata_file(metadata_file: str) -> ConversionMetadata | None:
     """
     metadata_path = os.path.join(metadata_file, ".sn2md.metadata.yaml")
     if os.path.exists(metadata_path):
-        with open(metadata_path, "r") as f:
-            data = yaml.safe_load(f)
-            metadata = ConversionMetadata(**data)
+        metadata_entries = _load_metadata_entries(metadata_path)
+        if not metadata_entries:
+            return None
 
-            if not os.path.exists(metadata.output_file):
-                raise ValueError("Output file does not exist anymore!")
+        if input_file:
+            metadata = next(
+                (entry for entry in metadata_entries if entry.input_file == input_file),
+                None,
+            )
+            if metadata is None:
+                return None
+        else:
+            if len(metadata_entries) > 1:
+                raise ValueError("Multiple metadata entries found; specify input file")
+            metadata = metadata_entries[0]
 
-            with open(metadata.output_file, "rb") as f:
-                output_hash = hashlib.sha1(f.read()).hexdigest()
+        if not os.path.exists(metadata.output_file):
+            raise ValueError("Output file does not exist anymore!")
 
-            if not os.path.exists(metadata.input_file):
-                raise ValueError("Input file does not exist anymore!")
+        with open(metadata.output_file, "rb") as f:
+            output_hash = hashlib.sha1(f.read()).hexdigest()
 
-            with open(metadata.input_file, "rb") as f:
-                source_hash = hashlib.sha1(f.read()).hexdigest()
+        if not os.path.exists(metadata.input_file):
+            raise ValueError("Input file does not exist anymore!")
 
-            if metadata.input_hash == source_hash:
-                raise ValueError(f"Input {metadata.input_file} has NOT changed!")
+        with open(metadata.input_file, "rb") as f:
+            source_hash = hashlib.sha1(f.read()).hexdigest()
 
-            if metadata.output_hash != output_hash:
-                raise ValueError(f"Output {metadata.output_file} HAS been changed!")
+        if metadata.input_hash == source_hash:
+            raise ValueError(f"Input {metadata.input_file} has NOT changed!")
 
-            return metadata
+        if metadata.output_hash != output_hash:
+            raise ValueError(f"Output {metadata.output_file} HAS been changed!")
+
+        return metadata
 
 
 def write_metadata_file(source_file: str, output_file: str) -> None:
@@ -52,15 +121,24 @@ def write_metadata_file(source_file: str, output_file: str) -> None:
         source_hash = hashlib.sha1(f.read()).hexdigest()
 
     metadata_path = os.path.join(output_path, ".sn2md.metadata.yaml")
-    with open(metadata_path, "w") as f:
-        yaml.dump(
-            asdict(ConversionMetadata(
-                input_file=source_file,
-                input_hash=source_hash,
-                output_file=output_file,
-                output_hash=output_hash,
-            )),
-            f,
+    existing_metadata = []
+    if os.path.exists(metadata_path):
+        existing_metadata = _load_metadata_entries(metadata_path)
+
+    metadata_entries = [
+        entry for entry in existing_metadata if entry.input_file != source_file
+    ]
+
+    metadata_entries.append(
+        ConversionMetadata(
+            input_file=source_file,
+            input_hash=source_hash,
+            output_file=output_file,
+            output_hash=output_hash,
         )
+    )
+
+    with open(metadata_path, "w") as f:
+        yaml.dump([asdict(entry) for entry in metadata_entries], f)
 
 

--- a/sn2md/types.py
+++ b/sn2md/types.py
@@ -93,6 +93,8 @@ class ConversionMetadata:
     output_file: str
     # The hash of the output file at the time it was generated.
     output_hash: str
+    # Version of the metadata entry
+    version: int = 1
 
 class ImageExtractor(ABC):
     @abstractmethod

--- a/tests/sn2md/test_importer.py
+++ b/tests/sn2md/test_importer.py
@@ -236,7 +236,9 @@ def test_verify_metadata_file(temp_dir):
 
     with patch("sn2md.importer.check_metadata_file") as mock_check_metadata:
         verify_metadata_file(config, output, filename)
-        mock_check_metadata.assert_called_once_with(os.path.join(output, "test"))
+        mock_check_metadata.assert_called_once_with(
+            os.path.join(output, "test"), filename
+        )
 
 
 def test_verify_metadata_file_nested_path(temp_dir):
@@ -266,7 +268,7 @@ def test_verify_metadata_file_nested_path(temp_dir):
 
     with patch("sn2md.importer.check_metadata_file") as mock_check_metadata:
         verify_metadata_file(config, output, filename)
-        mock_check_metadata.assert_called_once_with(expected_path)
+        mock_check_metadata.assert_called_once_with(expected_path, filename)
 
 
 @pytest.mark.parametrize("progress", [True, False])

--- a/tests/sn2md/test_metadata.py
+++ b/tests/sn2md/test_metadata.py
@@ -25,16 +25,20 @@ def temp_files(tmp_path):
 
 def test_write_metadata_file(temp_files):
     write_metadata_file(temp_files["source_file"], temp_files["output_file"])
-    
-    metadata_path = os.path.join(os.path.dirname(temp_files["output_file"]), ".sn2md.metadata.yaml")
+
+    metadata_path = os.path.join(
+        os.path.dirname(temp_files["output_file"]), ".sn2md.metadata.yaml"
+    )
     assert os.path.exists(metadata_path)
-    
+
     with open(metadata_path) as f:
         data = yaml.safe_load(f)
-        assert data["input_file"] == temp_files["source_file"]
-        assert data["output_file"] == temp_files["output_file"]
-        assert "input_hash" in data
-        assert "output_hash" in data
+        assert isinstance(data, list)
+        assert data[0]["version"] == 1
+        assert data[0]["input_file"] == temp_files["source_file"]
+        assert data[0]["output_file"] == temp_files["output_file"]
+        assert "input_hash" in data[0]
+        assert "output_hash" in data[0]
 
 
 def test_check_metadata_file_modified_input(temp_files):
@@ -46,7 +50,7 @@ def test_check_metadata_file_modified_input(temp_files):
         f.write("modified content")
     
     # Should return metadata since input changed
-    metadata = check_metadata_file(temp_files["metadata_dir"])
+    metadata = check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])
     assert isinstance(metadata, ConversionMetadata)
     assert metadata.input_file == temp_files["source_file"]
 
@@ -57,7 +61,7 @@ def test_check_metadata_file_unmodified_input(temp_files):
     
     # Should raise error since input hasn't changed
     with pytest.raises(ValueError, match="has NOT changed"):
-        check_metadata_file(temp_files["metadata_dir"])
+        check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])
 
 
 def test_check_metadata_file_modified_output(temp_files):
@@ -72,10 +76,76 @@ def test_check_metadata_file_modified_output(temp_files):
     
     # Should raise error since output was modified
     with pytest.raises(ValueError, match="HAS been changed"):
-        check_metadata_file(temp_files["metadata_dir"])
+        check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])
 
 
 def test_check_metadata_file_missing(temp_files):
     # No metadata file exists
-    result = check_metadata_file(temp_files["metadata_dir"])
+    result = check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])
     assert result is None
+
+
+def test_write_multiple_metadata_entries(temp_files):
+    write_metadata_file(temp_files["source_file"], temp_files["output_file"])
+
+    second_source = os.path.join(temp_files["metadata_dir"], "second.txt")
+    second_output = os.path.join(temp_files["metadata_dir"], "second.md")
+    with open(second_source, "w") as f:
+        f.write("secondary content")
+    with open(second_output, "w") as f:
+        f.write("# Secondary markdown")
+
+    write_metadata_file(second_source, second_output)
+
+    # Modify both sources to ensure metadata is considered stale and returned
+    with open(temp_files["source_file"], "w") as f:
+        f.write("updated content")
+
+    with open(second_source, "w") as f:
+        f.write("updated secondary content")
+
+    metadata = check_metadata_file(
+        temp_files["metadata_dir"], temp_files["source_file"]
+    )
+    assert metadata is not None
+    assert metadata.output_file == temp_files["output_file"]
+
+    second_metadata = check_metadata_file(temp_files["metadata_dir"], second_source)
+    assert second_metadata is not None
+    assert second_metadata.output_file == second_output
+
+
+def test_check_metadata_file_unversioned_backwards_compatibility(temp_files):
+    metadata_path = os.path.join(temp_files["metadata_dir"], ".sn2md.metadata.yaml")
+    # Write versioned metadata then strip the version to simulate legacy data
+    write_metadata_file(temp_files["source_file"], temp_files["output_file"])
+    with open(metadata_path) as f:
+        unversioned_data = yaml.safe_load(f)
+    for entry in (unversioned_data if isinstance(unversioned_data, list) else [unversioned_data]):
+        entry.pop("version", None)
+
+    with open(metadata_path, "w") as f:
+        yaml.safe_dump(unversioned_data, f)
+
+    with pytest.raises(ValueError, match="Input .* has NOT changed!"):
+        check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])
+
+
+def test_check_metadata_file_unknown_version(temp_files):
+    metadata_path = os.path.join(temp_files["metadata_dir"], ".sn2md.metadata.yaml")
+    with open(metadata_path, "w") as f:
+        yaml.dump(
+            [
+                {
+                    "version": 2,
+                    "input_file": temp_files["source_file"],
+                    "input_hash": "abc",
+                    "output_file": temp_files["output_file"],
+                    "output_hash": "def",
+                }
+            ],
+            f,
+        )
+
+    with pytest.raises(ValueError, match="Unsupported metadata version"):
+        check_metadata_file(temp_files["metadata_dir"], temp_files["source_file"])


### PR DESCRIPTION
## Summary
- add a version field to conversion metadata entries and serialize it for future migrations
- load both legacy unversioned metadata and the new version 1 format while rejecting unknown versions
- extend metadata tests to cover versioning and backward compatibility

## Testing
- PYENV_VERSION=3.11.12 PYTHONPATH=. pytest -o addopts="" tests/sn2md/test_metadata.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695913997164832682e8fda885d54e2d)