### PR TITLE
Fix TypeError when decoding note titles with grayscale color codes

### DIFF
--- a/sn2md/importer.py
+++ b/sn2md/importer.py
@@ -113,20 +113,35 @@ def create_notebook_context(notebook: Notebook, config: Config, model: str) -> d
             }
             for keyword in (notebook.keywords if notebook else [])
         ],
-        "titles": [
+        "titles": _extract_titles(notebook, config, model),
+    }
+
+
+def _extract_titles(notebook: Notebook | None, config: Config, model: str) -> list[dict]:
+    titles = []
+    for title in notebook.titles if notebook else []:
+        try:
+            image = convert_binary_to_image(notebook, title)
+        except Exception as e:
+            logger.warning(
+                "Skipping title on page %s: failed to decode (%s)",
+                title.get_page_number(),
+                e,
+            )
+            continue
+        titles.append(
             {
                 "page_number": title.get_page_number(),
                 "content": image_to_text(
-                    convert_binary_to_image(notebook, title),
+                    image,
                     config.api_key,
                     model,
                     config.title_prompt,
                 ),
                 "level": title.metadata["TITLELEVEL"],
             }
-            for title in (notebook.titles if notebook else [])
-        ],
-    }
+        )
+    return titles
 
 
 def create_context(

--- a/sn2md/importers/note.py
+++ b/sn2md/importers/note.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from sn2md.types import ImageExtractor
 
 import supernotelib as sn
+from supernotelib import color
 from supernotelib.converter import ImageConverter, VisibilityOverlay
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,23 @@ logger = logging.getLogger(__name__)
 
 def load_notebook(path: str) -> sn.Notebook:
     return sn.load_notebook(path)
+
+
+def _create_color_bytearray_with_fallback(self, mode, colormap, color_code, length):
+    """Backport of RattaRleX2Decoder's fallback to the base RattaRleDecoder:
+    title regions contain anti-aliased grayscale codes absent from the base
+    colormap; use the raw code value instead of crashing on a None lookup."""
+    if mode == color.MODE_RGB:
+        c = colormap.get(color_code)
+        if c is not None:
+            r, g, b = color.get_rgb(c)
+        else:
+            r, g, b = (color_code, color_code, color_code)
+        return bytearray((r, g, b,)) * length
+    c = colormap.get(color_code)
+    if c is None:
+        c = color_code
+    return bytearray((c,)) * length
 
 
 def convert_pages_to_pngs(
@@ -56,6 +74,11 @@ def convert_binary_to_image(notebook, title):
     with (
         patch.object(notebook, "get_width") as width_mock,
         patch.object(notebook, "get_height") as height_mock,
+        patch.object(
+            type(decoder),
+            "_create_color_bytearray",
+            _create_color_bytearray_with_fallback,
+        ),
     ):
         width_mock.return_value = int(titlerect[2])
         height_mock.return_value = int(titlerect[3])

--- a/tests/sn2md/importers/test_note.py
+++ b/tests/sn2md/importers/test_note.py
@@ -2,8 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import supernotelib as sn
+from supernotelib import color
 
-from sn2md.importers.note import (convert_notebook_to_pngs,
+from sn2md.importers.note import (_create_color_bytearray_with_fallback,
+                                   convert_notebook_to_pngs,
                                    convert_pages_to_pngs, load_notebook)
 
 
@@ -42,3 +44,22 @@ def test_convert_notebook_to_pngs(mock_notebook):
             assert result[0] == "fake_path/fake_path_0.png"
             assert result[1] == "fake_path/fake_path_1.png"
             assert result[2] == "fake_path/fake_path_2.png"
+
+
+def test_color_bytearray_fallback_known_grayscale():
+    # A code present in the colormap delegates to its mapped value.
+    colormap = {0x61: 0x00}
+    result = _create_color_bytearray_with_fallback(None, "L", colormap, 0x61, 3)
+    assert result == bytearray((0x00,)) * 3
+
+
+def test_color_bytearray_fallback_unknown_grayscale():
+    # An unknown code uses the raw code value instead of crashing on None.
+    result = _create_color_bytearray_with_fallback(None, "L", {}, 0x7F, 4)
+    assert result == bytearray((0x7F,)) * 4
+
+
+def test_color_bytearray_fallback_unknown_rgb():
+    # In RGB mode an unknown code becomes a (code, code, code) gray triple.
+    result = _create_color_bytearray_with_fallback(None, color.MODE_RGB, {}, 0x42, 2)
+    assert result == bytearray((0x42, 0x42, 0x42)) * 2

--- a/tests/sn2md/test_importer.py
+++ b/tests/sn2md/test_importer.py
@@ -242,6 +242,48 @@ def test_create_notebook_context():
         mock_convert_image.assert_called_once_with(mock_notebook, mock_title)
 
 
+def test_create_notebook_context_skips_undecodable_title():
+    mock_notebook = Mock()
+    mock_notebook.links = []
+    mock_notebook.keywords = []
+
+    bad_title = Mock()
+    bad_title.get_page_number.return_value = 1
+    bad_title.metadata = {"TITLELEVEL": 1}
+
+    good_title = Mock()
+    good_title.get_page_number.return_value = 2
+    good_title.metadata = {"TITLELEVEL": 1}
+
+    mock_notebook.titles = [bad_title, good_title]
+
+    config = Config(
+        output_path_template="{{file_basename}}",
+        output_filename_template="{{file_basename}}.md",
+        prompt="TO_MARKDOWN_TEMPLATE",
+        title_prompt="TO_TEXT_TEMPLATE",
+        template="{{markdown}}",
+        model="mock-model",
+        api_key="mock-key",
+    )
+
+    with patch("sn2md.importer.image_to_text") as mock_image_to_text, patch(
+        "sn2md.importer.convert_binary_to_image"
+    ) as mock_convert_image:
+        mock_image_to_text.return_value = "Good Title"
+        # First title fails to decode, second succeeds.
+        mock_convert_image.side_effect = [TypeError("boom"), Mock()]
+
+        context = create_notebook_context(mock_notebook, config, "gpt-4")
+
+        # The undecodable title is skipped, the import continues.
+        assert len(context["titles"]) == 1
+        assert context["titles"][0]["page_number"] == 2
+        assert context["titles"][0]["content"] == "Good Title"
+        mock_image_to_text.assert_called_once()
+        assert mock_convert_image.call_count == 2
+
+
 def test_verify_metadata_file(temp_dir):
     filename = os.path.join(temp_dir, "test.note")
     output = temp_dir


### PR DESCRIPTION
## Problem

Converting a `.note` file crashes **after** all pages have been processed, deep inside `supernotelib`'s decoder:

```
File ".../supernotelib/decoder.py", line 215, in _create_color_bytearray
    return bytearray((c,)) * length
TypeError: 'NoneType' object cannot be interpreted as an integer
```

The crash is not in page rendering — it's in **title-image extraction** (`convert_binary_to_image` in `sn2md/importers/note.py`), called from `create_notebook_context` to OCR each title region.

## Root cause

Title regions can contain anti-aliased grayscale color codes (observed range `0x05`–`0xff`) that are absent from the base `RattaRleDecoder`'s colormap (which defines only ~8 codes). An unknown code makes `colormap.get(code)` return `None`, so `bytearray((None,))` raises `TypeError`.

The newer `RattaRleX2Decoder` subclass already handles this exact case — when a code is missing it falls back to using the raw code value as the gray level. The base `RattaRleDecoder` lacks that fallback.

## Fix

1. **Backport the X2 fallback.** Add `_create_color_bytearray_with_fallback` (mirrors `RattaRleX2Decoder._create_color_bytearray`) and apply it as a scoped `patch.object(type(decoder), ...)` in `convert_binary_to_image`, alongside the existing width/height patches. It's a no-op for X2 notes and fixes X-series notes. Verified: all titles in the failing note now decode to valid images.

2. **Resilient title extraction.** `create_notebook_context`'s title loop now wraps each decode in `try/except`; a title that still fails is logged and skipped rather than aborting the entire (expensive, per-page LLM) import.

## Tests

- Unit tests for `_create_color_bytearray_with_fallback` (known/unknown grayscale codes, unknown RGB code).
- A test that `create_notebook_context` skips an undecodable title and continues.

All tests pass (`uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)